### PR TITLE
🔐 Document and decentralize Treasury operations

### DIFF
--- a/incidents/kms.md
+++ b/incidents/kms.md
@@ -1,0 +1,3 @@
+#  Key Managumnet
+
+This page tracks key management practices for sensitive systems, including how keys are created, stored, rotated, revoked, and reviewed during incident response.


### PR DESCRIPTION
https://github.com/blocktransfer/org-docs/pull/20/changes/e771f4eba67caf13dd36d452345d38d0b4dbadb3 adds a key management page, which has a lot of work to do. First, we need to spell out all the IAM keys and identity access more broadly, working on in https://github.com/orgs/blocktransfer/projects/4. This subsection can start the mapping of team --> AWS.

Second, and more significantly, this PR explains the distribution of keys for [`1846058*blocktransfer.com`](https://stellar.expert/explorer/public/account/GD2OUJ4QKAPESM2NVGREBZTLFJYMLPCGSUHZVRMTQMF5T34UODVHPRCY). There could be a future extension of Exhibit 1.24; however, I want to keep that with just us and the regulators for now. Once AWS is set up, we can doc the _existing_ (suboptimal) hot operations, which will then lead into a chat on Secrets Manager.